### PR TITLE
Cleanup: remove dlfcn & add __DATE__

### DIFF
--- a/bsdfetch.c
+++ b/bsdfetch.c
@@ -23,7 +23,6 @@
 #include <sys/types.h>
 #include <sys/sysctl.h>
 #include <sys/utsname.h>
-#include <dlfcn.h>
 #if defined(__FreeBSD__) || defined(__DragonFly__) || defined(__MidnightBSD__)
 #include <time.h>
 #include <sys/vmmeter.h>
@@ -369,9 +368,9 @@ static void get_sysinfo(void) {
 }
 
 static void version(void) {
-	_SILENT fprintf(stdout, "%s - version %s (2022)\n",
+	_SILENT fprintf(stdout, "%s - version %s (%s)\n",
 			_PRG_NAME,
-			_VERSION
+			__DATE__
 			);
 
 	exit(EXIT_SUCCESS);

--- a/bsdfetch.c
+++ b/bsdfetch.c
@@ -370,6 +370,7 @@ static void get_sysinfo(void) {
 static void version(void) {
 	_SILENT fprintf(stdout, "%s - version %s (%s)\n",
 			_PRG_NAME,
+			_VERSION,
 			__DATE__
 			);
 


### PR DESCRIPTION
Since there are no shared library calls, `dlfcn.h` header is unused here.
And instead of a year, a full year (when the binary was created) would be nice!

Tested on HardenedBSD (generally FreeBSD)
![image](https://user-images.githubusercontent.com/71683721/209512730-17fa58b4-1921-452f-a2db-96158ecbd78f.png)

