### PR TITLE
Get user/shell update

### DIFF
--- a/bsdfetch.c
+++ b/bsdfetch.c
@@ -106,14 +106,10 @@ static void get_shell(void) {
 	uid_t uid = getuid();
 	struct passwd *pw = getpwuid(uid);
 
-	if (getenv("SHELL")) {
-		sh = getenv("SHELL");
-	} else {
-		if ((sh = getenv("SHELL")) == NULL || *sh == '\0') {
-			if (pw == NULL)
-				die(errno, __LINE__);
-			sh = pw->pw_shell;
-		}
+	if ((sh = getenv("SHELL")) == NULL || *sh == '\0') {
+		if (pw == NULL)
+			die(errno, __LINE__);
+		sh = pw->pw_shell;
 	}
 
 	if ((p = strrchr(sh, c)) != NULL && *(p+1) != '\0')
@@ -127,14 +123,10 @@ static void get_user(void) {
 	uid_t uid = getuid();
 	struct passwd *pw = getpwuid(uid);
 
-	if (getenv("USER")) {
-		user = getenv("USER");
-	} else {
-		if ((user = getenv("USER")) == NULL || *user == '\0') {
-			if (pw == NULL)
-				die(errno, __LINE__);
-			user = pw->pw_name;
-		}
+	if ((user = getenv("USER")) == NULL || *user == '\0') {
+		if (pw == NULL)
+			die(errno, __LINE__);
+		user = pw->pw_name;
 	}
 
 	show("User", user);

--- a/bsdfetch.c
+++ b/bsdfetch.c
@@ -103,7 +103,7 @@ static void get_shell(void) {
 	char *sh;
 	char *p;
 	const char c = '/';
-	uid_t uid = geteuid();
+	uid_t uid = getuid();
 	struct passwd *pw = getpwuid(uid);
 
 	if (getenv("SHELL")) {
@@ -124,7 +124,7 @@ static void get_shell(void) {
 
 static void get_user(void) {
 	char *user;
-	uid_t uid = geteuid();
+	uid_t uid = getuid();
 	struct passwd *pw = getpwuid(uid);
 
 	if (getenv("USER")) {


### PR DESCRIPTION
1. If utility has set-user-ID bit ON, it reports executable's owner as "User" instead of who run it. So I use getuid(2) instead of geteuid(2).
2. Fix User/Shell report rows in case when environment variables USER and/or SHELL present but are empty